### PR TITLE
Feat/preparing audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ You can create as many flows of spendings as you want, for multiple domains or e
 When you create a flow of spending, you specify for which domain it is valid and what yearly allowance (limit_price) you give to this contract. To disable this allowance you need to use the same account and provide the same domain and limit_price. We emit events to allow users to easily retrieve their existing allowances (so they will be able to see them in the front).
 Using limit_price as key and not a value in the storage mapping is a storage optimization.
 
-### 4. Admin
+### 4. Your flow capacity is what will be spent
+The flow capacity (limit_price) is what will be taken from your account, even if the domain is less expensive. This allows us to optimize the contract execution to not want to encourage users to allow more than require. We maintain the technical possibility of recovering the funds in case someone makes a mistake but we do not guarantee the fact of returning them, especially for a small amount.
+
+### 5. Admin
 This contract is controled by an admin who has the ability to fully disable the contract renewals for ever (if a vulnerability was found or the contract deprecated). It has also the power to change the allowed renewer (address allowed to renew domains of other people). This allowed renewer has to be trusted by StarknetID (but not the users) because it is in control of the tax_price. If the admin or renewer was compromised, the latter would still do its job but do not send tax money to StarknetID.
 
 # How to build/test?

--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ Here are the guarantees offered by this contract:
 
 This contract is not upgradeable, we cannot change its code. This means that even if we wanted to be dishonest, we could not circumvent these rules.
 
+# Technical notes
+
+Here are some technical choices we made:
+
+### 1. You can renew a domain you don't own.
+This is useful if you want your domain to be controled by a smartcontract but you still want to pay for its renewal.
+
+### 2. You can create multiple flows of spendings
+You can create as many flows of spendings as you want, for multiple domains or even the same domain. If you open two flows for the same domain it will still be renewed only once a year because we can only renew it if it expires in less than a month.
+
+### 3. You need initial parameters to disable a flow of spending
+When you create a flow of spending, you specify for which domain it is valid and what yearly allowance (limit_price) you give to this contract. To disable this allowance you need to use the same account and provide the same domain and limit_price. We emit events to allow users to easily retrieve their existing allowances (so they will be able to see them in the front).
+Using limit_price as key and not a value in the storage mapping is a storage optimization.
+
+### 4. Admin
+This contract is controled by an admin who has the ability to fully disable the contract renewals for ever (if a vulnerability was found or the contract deprecated). It has also the power to change the allowed renewer (address allowed to renew domains of other people). This allowed renewer has to be trusted by StarknetID (but not the users) because it is in control of the tax_price. If the admin or renewer was compromised, the latter would still do its job but do not send tax money to StarknetID.
+
 # How to build/test?
 
 This was built using scarb.

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -14,4 +14,4 @@ sierra = true
 casm = true
 
 # Emit Python-powered hints in order to run compiled CASM class with legacy Cairo VM.
-casm-add-pythonic-hints = true
+casm-add-pythonic-hints = false

--- a/src/auto_renewal.cairo
+++ b/src/auto_renewal.cairo
@@ -133,9 +133,7 @@ mod AutoRenewal {
         // allowing naming 2^251-1, aka infinite approval according to its implementation
         // when moving funds, the storage variable won't be updated, saving gas
         IERC20CamelDispatcher { contract_address: erc20_addr }
-            .approve(
-                naming_addr, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            );
+            .approve(naming_addr, integer::BoundedInt::max());
     }
 
     #[external(v0)]

--- a/src/auto_renewal.cairo
+++ b/src/auto_renewal.cairo
@@ -267,12 +267,12 @@ mod AutoRenewal {
             let contract = get_contract_address();
             let erc20 = self.erc20_contract.read();
             let _tax_contract = self.tax_contract.read();
-            // Transfer limit_price + tax price
+            // Transfer limit_price (including tax)
             IERC20CamelDispatcher { contract_address: erc20 }
-                .transferFrom(renewer, contract, limit_price + tax_price);
+                .transferFrom(renewer, contract, limit_price);
             // transfer tax price to tax contract address
             IERC20CamelDispatcher { contract_address: erc20 }.transfer(_tax_contract, tax_price);
-            // Approve & renew domain
+            // Approve & renew domain (approving limit_price is more than necessary if tax is not null)
             IERC20CamelDispatcher { contract_address: erc20 }.approve(naming, limit_price);
             // reentrancy could only happen here if naming was compromised
             // and it would only allow to reorder events

--- a/src/auto_renewal.cairo
+++ b/src/auto_renewal.cairo
@@ -295,7 +295,7 @@ mod AutoRenewal {
             // last_renewal is updated before external contract calls to prevent reentrancy attacks
             // if the naming contract was compromised
             self.last_renewal.write((renewer, root_domain), block_timestamp);
-            // events is sent before calls to other contracts a reordering via reentrancy attack
+            // events is sent before calls to other contracts to prevent a reordering via reentrancy attack
             self
                 .emit(
                     Event::DomainRenewed(

--- a/src/tests/common.cairo
+++ b/src/tests/common.cairo
@@ -15,6 +15,9 @@ use auto_renew_contract::auto_renewal::{
     AutoRenewal, IAutoRenewal, IAutoRenewalDispatcher, IAutoRenewalDispatcherTrait,
 };
 use auto_renew_contract::auto_renewal::AutoRenewal::{ContractState as AutoRenewalContractState,};
+use starknet::{
+    get_contract_address, testing::set_contract_address, contract_address::ContractAddressZeroable
+};
 
 fn deploy_contracts() -> (
     IERC20CamelDispatcher,
@@ -35,8 +38,10 @@ fn deploy_contracts() -> (
     );
     // autorenewal
     let renewal = utils::deploy(
-        AutoRenewal::TEST_CLASS_HASH, array![naming.into(), eth.into(), 0x111, ADMIN().into()]
+        AutoRenewal::TEST_CLASS_HASH,
+        array![naming.into(), eth.into(), 0x111, ADMIN().into(), ADMIN().into()]
     );
+    set_contract_address(ADMIN());
 
     (
         IERC20CamelDispatcher { contract_address: eth },

--- a/src/tests/test_renewals.cairo
+++ b/src/tests/test_renewals.cairo
@@ -242,17 +242,18 @@ fn test_renew_with_metadata() {
     // buy TH0RGAL_DOMAIN & OTHER_DOMAIN
     testing::set_contract_address(ADMIN());
     let (_, price) = pricing.compute_buy_price(7, 365);
-    erc20.approve(naming.contract_address, price);
+    let limit_price = price + tax_price;
+    erc20.approve(naming.contract_address, limit_price);
     starknetid.mint(token_id);
     naming.buy(token_id, TH0RGAL_DOMAIN(), 365_u16, ZERO(), ZERO(), 0, metadata);
 
-    autorenewal.enable_renewals(TH0RGAL_DOMAIN(), price, metadata);
+    autorenewal.enable_renewals(TH0RGAL_DOMAIN(), limit_price, metadata);
     erc20.approve(autorenewal.contract_address, integer::BoundedInt::max());
 
     testing::set_block_timestamp(BLOCK_TIMESTAMP_ADD());
 
     // Should renew domain & send tax price to tax contract
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, tax_price, metadata);
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), limit_price, tax_price, metadata);
     let tax_balance = erc20.balanceOf(tax_contract);
     assert(tax_balance == tax_price, 'tax balance should be 100');
 }


### PR DESCRIPTION
This pull request closes #12 

Changes:
- disable pythonic hints (unused)
- include tax_price in limit price (otherwise we could steal users' money)
- remove per renew approvals (seems to be no longer needed)
- add a constraint on who can call renew (needed to prevent someone from calling the contract with empty taxes for everyone)
- add a way to claim ethereum lost on the contract
- tests for those two latter features
- moved event before contracts calls in _renew to prevent events reordering

This also added some explanations:
- How we prevent reentrancy
- Design specifications (you can open multiple flows)
- Why we need to specify the limit price to disable a payment flow
- Why we will take limit_price, even if it is more than required