### PR TITLE
Fix/audit suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,13 @@ Here are some technical choices we made:
 ### 1. You can renew a domain you don't own.
 This is useful if you want your domain to be controled by a smartcontract but you still want to pay for its renewal.
 
-### 2. You can create multiple flows of spendings
-You can create as many flows of spendings as you want, for multiple domains or even the same domain. If you open two flows for the same domain it will still be renewed only once a year because we can only renew it if it expires in less than a month.
+### 2. You need a domain name to disable a flow of spending
+When you create a flow of spending, you specify for which domain it is valid and what yearly allowance (limit_price) you give to this contract. To disable this allowance you need to use the same account and provide the same domain. We emit events to allow users to easily retrieve these data so they will be able to see them in the front.
 
-### 3. You need initial parameters to disable a flow of spending
-When you create a flow of spending, you specify for which domain it is valid and what yearly allowance (limit_price) you give to this contract. To disable this allowance you need to use the same account and provide the same domain and limit_price. We emit events to allow users to easily retrieve their existing allowances (so they will be able to see them in the front).
-Using limit_price as key and not a value in the storage mapping is a storage optimization.
+### 3. Your allowance is what we can spend
+Your spending limit, sometimes called 'limit_price' or 'allowance', represents the maximum we can deduct from your account. Even if the actual cost is lower, it's best to set this limit carefully. While we can often refund overcharges or errors, we don't guarantee refunds, especially for small amounts.
 
-### 4. Your flow capacity is what will be spent
-The flow capacity (limit_price) is what will be taken from your account, even if the domain is less expensive. This allows us to optimize the contract execution to not want to encourage users to allow more than require. We maintain the technical possibility of recovering the funds in case someone makes a mistake but we do not guarantee the fact of returning them, especially for a small amount.
-
-### 5. Admin
+### 4. Admin
 This contract is controled by an admin who has the ability to fully disable the contract renewals for ever (if a vulnerability was found or the contract deprecated). It has also the power to change the allowed renewer (address allowed to renew domains of other people). This allowed renewer has to be trusted by StarknetID (but not the users) because it is in control of the tax_price. If the admin or renewer was compromised, the latter would still do its job but do not send tax money to StarknetID.
 
 # How to build/test?

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Here are some technical choices we made:
 This is useful if you want your domain to be controled by a smartcontract but you still want to pay for its renewal.
 
 ### 2. You need a domain name to disable a flow of spending
-When you create a flow of spending, you specify for which domain it is valid and what yearly allowance (limit_price) you give to this contract. To disable this allowance you need to use the same account and provide the same domain. We emit events to allow users to easily retrieve these data so they will be able to see them in the front.
+When you create a flow of spending, you specify for which domain it is valid and what yearly allowance you give to this contract. To disable this allowance you need to use the same account and provide the same domain. We emit events to allow users to easily retrieve these data so they will be able to see them in the front.
 
 ### 3. Your allowance is what we can spend
-Your spending limit, sometimes called 'limit_price' or 'allowance', represents the maximum we can deduct from your account. Even if the actual cost is lower, it's best to set this limit carefully. While we can often refund overcharges or errors, we don't guarantee refunds, especially for small amounts.
+Your spending limit, sometimes called 'allowance', represents the maximum we can deduct from your account. Even if the actual cost is lower, it's best to set this limit carefully. While we can often refund overcharges or errors, we don't guarantee refunds, especially for small amounts.
 
 ### 4. Admin
 This contract is controled by an admin who has the ability to fully disable the contract renewals for ever (if a vulnerability was found or the contract deprecated). It has also the power to change the allowed renewer (address allowed to renew domains of other people). This allowed renewer has to be trusted by StarknetID (but not the users) because it is in control of the tax_price. If the admin or renewer was compromised, the latter would still do its job but do not send tax money to StarknetID.

--- a/src/auto_renewal.cairo
+++ b/src/auto_renewal.cairo
@@ -59,7 +59,7 @@ mod AutoRenewal {
         temp_admin: ContractAddress,
         whitelisted_renewer: ContractAddress,
         can_renew: bool,
-        // (renewer, domain, limit_price) -> 1 or 0
+        // (renewer, domain) -> limit_price
         renewing_allowance: LegacyMap::<(ContractAddress, felt252), u256>,
         // (renewer, domain) -> timestamp
         last_renewal: LegacyMap::<(ContractAddress, felt252), u64>,
@@ -213,7 +213,6 @@ mod AutoRenewal {
                 )
         }
 
-        // limit_price can be found via the EnabledRenewal events
         fn disable_renewals(ref self: ContractState, domain: felt252) {
             let caller = get_caller_address();
             self.renewing_allowance.write((caller, domain), 0);

--- a/src/auto_renewal.cairo
+++ b/src/auto_renewal.cairo
@@ -48,13 +48,7 @@ mod AutoRenewal {
     use starknet::ContractAddress;
     use starknet::{get_caller_address, get_contract_address, get_block_timestamp};
     use starknet::contract_address::ContractAddressZeroable;
-    use traits::{TryInto, Into};
-    use option::OptionTrait;
     use array::ArrayTrait;
-    use integer::u64_try_from_felt252;
-
-    use debug::PrintTrait;
-
     use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
     use naming::interface::naming::{INamingDispatcher, INamingDispatcherTrait};
 

--- a/src/auto_renewal.cairo
+++ b/src/auto_renewal.cairo
@@ -112,6 +112,8 @@ mod AutoRenewal {
         renewer: ContractAddress,
         days: felt252,
         limit_price: u256,
+        tax_price: u256,
+        metadata: felt252,
         timestamp: u64,
     }
 
@@ -373,6 +375,8 @@ mod AutoRenewal {
                             renewer,
                             days: 365,
                             limit_price,
+                            tax_price,
+                            metadata,
                             timestamp: block_timestamp
                         }
                     )

--- a/src/auto_renewal.cairo
+++ b/src/auto_renewal.cairo
@@ -209,6 +209,8 @@ mod AutoRenewal {
             );
             assert(domain.len() == renewer.len(), 'Domain & renewer mismatch len');
             assert(domain.len() == limit_price.len(), 'Domain & price mismatch len');
+            assert(domain.len() == tax_price.len(), 'Domain & tax_price mismatch len');
+            assert(domain.len() == metadata.len(), 'Domain & metadata mismatch len');
 
             let mut domain = domain;
             let mut renewer = renewer;
@@ -220,11 +222,11 @@ mod AutoRenewal {
                 if domain.len() == 0 {
                     break;
                 }
-                let _domain = domain.pop_front().expect('pop_front error');
-                let _renewer = renewer.pop_front().expect('pop_front error');
-                let _limit_price = limit_price.pop_front().expect('pop_front error');
-                let _tax_price = tax_price.pop_front().expect('pop_front error');
-                let _metadata = metadata.pop_front().expect('pop_front error');
+                let _domain = domain.pop_front().unwrap();
+                let _renewer = renewer.pop_front().unwrap();
+                let _limit_price = limit_price.pop_front().unwrap();
+                let _tax_price = tax_price.pop_front().unwrap();
+                let _metadata = metadata.pop_front().unwrap();
                 self._renew(*_domain, *_renewer, *_limit_price, *_tax_price, *_metadata);
             }
         }

--- a/src/auto_renewal.cairo
+++ b/src/auto_renewal.cairo
@@ -130,7 +130,7 @@ mod AutoRenewal {
         self.admin.write(admin_addr);
         self.whitelisted_renewer.write(whitelisted_renewer);
         self.can_renew.write(true);
-        // allowing naming 2^251-1, aka infinite approval according to its implementation
+        // allowing naming 2^256-1, aka infinite approval according to its implementation
         // when moving funds, the storage variable won't be updated, saving gas
         IERC20CamelDispatcher { contract_address: erc20_addr }
             .approve(naming_addr, integer::BoundedInt::max());

--- a/src/tests/test_renewals.cairo
+++ b/src/tests/test_renewals.cairo
@@ -314,7 +314,7 @@ fn test_change_admin() {
     // initialize contracts
     let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
 
-    // buy TH0RGAL_DOMAIN for a year
+    // change admin
     testing::set_contract_address(ADMIN());
     autorenewal.start_admin_update(OTHER());
     testing::set_contract_address(OTHER());

--- a/src/tests/test_renewals.cairo
+++ b/src/tests/test_renewals.cairo
@@ -41,13 +41,13 @@ fn test_toggle_renewal() {
     starknetid.mint(token_id);
     naming.buy(token_id, TH0RGAL_DOMAIN(), 365_u16, ZERO(), ZERO(), 0, 0);
 
-    // Should test autorenewal has been toggled for TH0RGAL_DOMAIN by USER() for limit_price
-    let limit_price: u256 = 600.into();
-    autorenewal.enable_renewals(TH0RGAL_DOMAIN(), limit_price, 0);
+    // Should test autorenewal has been toggled for TH0RGAL_DOMAIN by USER() for allowance
+    let allowance: u256 = 600.into();
+    autorenewal.enable_renewals(TH0RGAL_DOMAIN(), allowance, 0);
     let renew = autorenewal.get_renewing_allowance(TH0RGAL_DOMAIN(), ADMIN());
-    assert(renew == limit_price, 'renew should be true');
+    assert(renew == allowance, 'renew should be true');
 
-    // Should test autorenewal has been untoggled for OTHER_DOMAIN by USER() for limit_price
+    // Should test autorenewal has been untoggled for OTHER_DOMAIN by USER() for allowance
     autorenewal.disable_renewals(TH0RGAL_DOMAIN());
     let renew = autorenewal.get_renewing_allowance(TH0RGAL_DOMAIN(), ADMIN());
     assert(renew == 0, 'renew should be false');
@@ -109,7 +109,7 @@ fn test_renew_fail_not_toggled() {
 #[should_panic(
     expected: ('u256_sub Overflow', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED')
 )]
-fn test_renew_fail_wrong_limit_price() {
+fn test_renew_fail_wrong_allowance() {
     // initialize contracts
     let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
     let token_id: u128 = 1;
@@ -124,7 +124,7 @@ fn test_renew_fail_wrong_limit_price() {
 
     testing::set_block_timestamp(BLOCK_TIMESTAMP_ADD());
 
-    // Toggle renewal for a limit_price
+    // Toggle renewal for a allowance
     let lower_price: u256 = 300.into();
     autorenewal.enable_renewals(TH0RGAL_DOMAIN(), lower_price, 0);
     erc20.approve(autorenewal.contract_address, integer::BoundedInt::max());
@@ -242,12 +242,12 @@ fn test_renew_with_metadata() {
     // buy TH0RGAL_DOMAIN & OTHER_DOMAIN
     testing::set_contract_address(ADMIN());
     let (_, price) = pricing.compute_buy_price(7, 365);
-    let limit_price = price + tax_price;
-    erc20.approve(naming.contract_address, limit_price);
+    let allowance = price + tax_price;
+    erc20.approve(naming.contract_address, allowance);
     starknetid.mint(token_id);
     naming.buy(token_id, TH0RGAL_DOMAIN(), 365_u16, ZERO(), ZERO(), 0, metadata);
 
-    autorenewal.enable_renewals(TH0RGAL_DOMAIN(), limit_price, metadata);
+    autorenewal.enable_renewals(TH0RGAL_DOMAIN(), allowance, metadata);
     erc20.approve(autorenewal.contract_address, integer::BoundedInt::max());
 
     testing::set_block_timestamp(BLOCK_TIMESTAMP_ADD());

--- a/src/tests/test_renewals.cairo
+++ b/src/tests/test_renewals.cairo
@@ -78,7 +78,7 @@ fn test_renew_domain() {
     let expiry = naming.domain_to_data(array![TH0RGAL_DOMAIN()].span()).expiry;
     assert(expiry == (86400 * 365) + BLOCK_TIMESTAMP().into(), 'expiry should be 365 days');
 
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), 0, 0);
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, 0, 0);
 
     let new_expiry = naming.domain_to_data(array![TH0RGAL_DOMAIN()].span()).expiry;
     let limit: u256 = ((86400 * 345) + BLOCK_TIMESTAMP_ADD().into()).into();
@@ -87,7 +87,7 @@ fn test_renew_domain() {
 
 #[test]
 #[available_gas(20000000)]
-#[should_panic(expected: ('Renewal not toggled for domain', 'ENTRYPOINT_FAILED',))]
+#[should_panic(expected: ('Renewal allowance insufficient', 'ENTRYPOINT_FAILED',))]
 fn test_renew_fail_not_toggled() {
     // initialize contracts
     let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
@@ -101,7 +101,7 @@ fn test_renew_fail_not_toggled() {
     naming.buy(token_id, TH0RGAL_DOMAIN(), 365_u16, ZERO(), ZERO(), 0, 0);
 
     // Should revert because ADMIN() has not toggled renewals for TH0RGAL_DOMAIN
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), 0, 0);
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, 0, 0);
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn test_renew_fail_wrong_limit_price() {
     erc20.approve(autorenewal.contract_address, integer::BoundedInt::max());
 
     // Should revert because price of renewing domain is higher than limit price
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), 0, 0);
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), lower_price, 0, 0);
 }
 
 #[test]
@@ -153,7 +153,7 @@ fn test_renew_fail_expiry() {
     erc20.approve(autorenewal.contract_address, integer::BoundedInt::max());
 
     // Should revert because TH0RGAL_DOMAIN will not expire within a month
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), 0, 0);
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, 0, 0);
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn test_renew_expired_domain() {
     assert(expiry < BLOCK_TIMESTAMP_EXPIRED().into(), 'domain should be expired');
 
     // Should renew TH0RGAL_DOMAIN for a year even if it is expired
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), 0, 0);
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, 0, 0);
     let new_expiry = naming.domain_to_data(array![TH0RGAL_DOMAIN()].span()).expiry;
     let limit: u256 = ((86400 * 345) + BLOCK_TIMESTAMP_EXPIRED().into()).into();
     assert(new_expiry.into() >= limit, 'new expiry should be 365 days');
@@ -216,6 +216,7 @@ fn test_renew_domains() {
         .batch_renew(
             array![TH0RGAL_DOMAIN(), OTHER_DOMAIN()].span(),
             array![ADMIN(), ADMIN()].span(),
+            array![price, price].span(),
             array![0, 0].span(),
             array![0, 0].span()
         );
@@ -252,7 +253,7 @@ fn test_renew_with_metadata() {
     testing::set_block_timestamp(BLOCK_TIMESTAMP_ADD());
 
     // Should renew domain & send tax price to tax contract
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), tax_price, metadata);
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, tax_price, metadata);
     let tax_balance = erc20.balanceOf(tax_contract);
     assert(tax_balance == tax_price, 'tax balance should be 100');
 }
@@ -300,7 +301,7 @@ fn test_renew_with_updated_whitelisted_renewer() {
     let new_renewer = contract_address_const::<0x456>();
     autorenewal.update_whitelisted_renewer(new_renewer);
     testing::set_contract_address(new_renewer);
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), 0, 0);
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, 0, 0);
 
     let new_expiry = naming.domain_to_data(array![TH0RGAL_DOMAIN()].span()).expiry;
     let limit: u256 = ((86400 * 345) + BLOCK_TIMESTAMP_ADD().into()).into();
@@ -396,5 +397,5 @@ fn test_renew_disabled_contract_fails() {
 
     autorenewal.toggle_off();
 
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), 0, 0);
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, 0, 0);
 }

--- a/src/tests/test_renewals.cairo
+++ b/src/tests/test_renewals.cairo
@@ -310,6 +310,21 @@ fn test_renew_with_updated_whitelisted_renewer() {
 
 #[test]
 #[available_gas(20000000)]
+fn test_change_admin() {
+    // initialize contracts
+    let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
+
+    // buy TH0RGAL_DOMAIN for a year
+    testing::set_contract_address(ADMIN());
+    autorenewal.start_admin_update(OTHER());
+    testing::set_contract_address(OTHER());
+    autorenewal.confirm_admin_update();
+    // should succeed only if OTHER() is the new admin
+    autorenewal.toggle_off();
+}
+
+#[test]
+#[available_gas(20000000)]
 #[should_panic(expected: ('Caller not admin', 'ENTRYPOINT_FAILED',))]
 fn test_update_tax_addr_fail() {
     // initialize contracts


### PR DESCRIPTION
This pull request implements the changes that were suggested during the audits and code reviews.

# Big changes:

## `limit_price` was replaced by an allowance

### What it means:
Instead of having a ``renewing_allowance`` storage mapping defines as:
```(renewer, domain, limit_price) -> 1 or 0```
We have:
```(renewer, domain) -> limit_price```

### Why?
- It is actually cheaper. Even though limit_price is a uint256 made of two felts, the high part will always be zero and thus have no associated storage cost. In addition it reduces the amount of hashes required to compute the storage address.
- It means less data to index and makes the logic easier to understand.
- It makes sure one user can only allow one flow of payment.

## Replaces `limit_price(s)` by `domain_price(s)` in `_renew`, `renew` and `batch_renew`

### What it means:
The whitelisted renewer no longer has to specify the yearly allowance set by every user. Instead he has to specify the expected domain_price. The contract will still ensure `(domain_price + tax_price) <= allowance` so this doesn't change the security guarantees. 

### Why?
It allows us however to debit less money from users if they allowed us more than needed. As before there is no guarantee about that, but we think having that possibility could be useful to avoid getting too much dust on the contract, especially if the stark domain prices decrease and users didn't have time to update their allowance.

# Small changes:
- removed unused imports
- fixed inconsistent sanity checks of span lengths
- fixed incorrect comments & readme
- added a two step process for updating the admin
- added more events for helping user to track the contract state

closes #17 